### PR TITLE
Symlink rubocop config to local dir

### DIFF
--- a/lib/fix_db_schema_conflicts/tasks/db.rake
+++ b/lib/fix_db_schema_conflicts/tasks/db.rake
@@ -19,6 +19,10 @@ namespace :db do
       rubocop_yml = File.expand_path("../../../../#{autocorrect_config}", __FILE__)
 
       begin
+        # Temporarily symlink the rubocop config file into the working directory so that rubocop
+        # can find the ruby version correctly. Without this, rubocop will start looking from the
+        # config file's path, deep inside this gem, where it won't be able to find your project's
+        # ruby version.
         local_filename = generate_local_filename
         FileUtils.symlink(rubocop_yml, local_filename)
         `bundle exec rubocop --auto-correct --config #{local_filename} #{filename.shellescape}`

--- a/lib/fix_db_schema_conflicts/tasks/db.rake
+++ b/lib/fix_db_schema_conflicts/tasks/db.rake
@@ -1,6 +1,10 @@
 require 'shellwords'
 require_relative '../autocorrect_configuration'
 
+def generate_local_filename
+  "tmp_rubocop_schema.#{SecureRandom.urlsafe_base64}.yml"
+end
+
 namespace :db do
   namespace :schema do
     task :dump do
@@ -13,7 +17,14 @@ namespace :db do
       end
       autocorrect_config = FixDBSchemaConflicts::AutocorrectConfiguration.load
       rubocop_yml = File.expand_path("../../../../#{autocorrect_config}", __FILE__)
-      `bundle exec rubocop --auto-correct --config #{rubocop_yml} #{filename.shellescape}`
+
+      begin
+        local_filename = generate_local_filename
+        FileUtils.symlink(rubocop_yml, local_filename)
+        `bundle exec rubocop --auto-correct --config #{local_filename} #{filename.shellescape}`
+      ensure
+        File.delete(local_filename) if File.exist?(local_filename)
+      end
     end
   end
 end


### PR DESCRIPTION
Ran into a subtle bug where rubocop on CircleCI thinks the ruby version is 2.3 and was (correctly) applying the frozen_string_literal autocomplete rule. Locally, rubocop thinks the ruby version is 2.2 (default fallback), and so does not apply the rule. This is causing `rake db:schema:dump` to produce a different `schema.rb` locally vs in CI.

This gem loads a config file from deep inside the gem (`/Users/trevorcreech/.rbenv/versions/2.3.4/lib/ruby/gems/2.3.0/bundler/gems/fix-db-schema-conflicts-05488d244475/.rubocop_schema.53.yml` locally). This causes Rubocop to use that as a starting point to determine the ruby version, which it does by traversing up, looking for either a `.ruby-version` file or a `Gemfile.lock` with a ruby version. Since rbenv installs gems into your homedir, it never finds those, and then defaults to 2.2.

Fix: temporarily symlink the config file to the current directory, which lets rubocop correctly find our `.ruby-version` file.